### PR TITLE
fix: skills directory path uses singular 'skill' instead of plural 'skills'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-lazy-loader",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-lazy-loader",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -194,7 +194,7 @@ export async function loadSkillsFromDir(
  * Discover skills from opencode global directory (~/.config/opencode/skill/)
  */
 export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
-  const opencodeSkillsDir = join(homedir(), '.config', 'opencode', 'skill')
+  const opencodeSkillsDir = join(homedir(), '.config', 'opencode', 'skills')
   return loadSkillsFromDir(opencodeSkillsDir, 'opencode')
 }
 
@@ -202,7 +202,7 @@ export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
  * Discover skills from opencode project directory (.opencode/skill/)
  */
 export async function discoverOpencodeProjectSkills(): Promise<LoadedSkill[]> {
-  const opencodeProjectDir = join(process.cwd(), '.opencode', 'skill')
+  const opencodeProjectDir = join(process.cwd(), '.opencode', 'skills')
   return loadSkillsFromDir(opencodeProjectDir, 'opencode-project')
 }
 


### PR DESCRIPTION
﻿Closes #10

## Summary

Fixes the skills directory lookup paths from 'skill' (singular) to 'skills' (plural) to match OpenCode's standard directory layout.

## Changes

- src/skill-loader.ts: Changed 'skill' → 'skills' in discoverOpencodeGlobalSkills and discoverOpencodeProjectSkills
- package-lock.json: Fixed version field stuck at 1.0.1 while package.json was already at 1.0.3

## Testing

Skills placed in ~/.config/opencode/skills/ and .opencode/skills/ are now properly discovered.
