### PR TITLE
Fix v1.0.4 release regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Or install it locally:
 
 ## Quick Start
 
-This repo includes a working example skill. After installing the plugin, try:
+This repository includes a working project skill. From a clone of the repository,
+try:
 
 ```
 skill(name="playwright-example")
@@ -62,7 +63,10 @@ Then use the embedded MCP:
 skill_mcp(mcp_name="playwright", tool_name="browser_navigate", arguments='{"url": "https://example.com"}')
 ```
 
-See [`.opencode/skills/playwright-example/SKILL.md`](.opencode/skills/playwright-example/SKILL.md) for the full example.
+The npm package does not install example skills into your OpenCode configuration.
+When installing from npm, copy
+[`.opencode/skills/playwright-example/SKILL.md`](.opencode/skills/playwright-example/SKILL.md)
+to one of the supported skill roots below before trying it.
 
 ## Usage
 

--- a/src/__tests__/skill-loader.test.ts
+++ b/src/__tests__/skill-loader.test.ts
@@ -101,7 +101,7 @@ describe('skill discovery', () => {
     expect(skills).toHaveLength(1)
     expect(skills[0]).toMatchObject({
       name: 'shared',
-      scope: 'opencode-project',
+      scope: 'claude-project',
       mcpConfig: {
         'project-mcp': {
           command: ['node', 'server.js']

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -223,7 +223,7 @@ async function discoverNativeProjectSkills(): Promise<LoadedSkill[][]> {
 }
 
 /**
- * Discover all skills from both opencode locations
+ * Discover skills from all supported global and project roots
  * Priority: project > global
  */
 export async function discoverSkills(): Promise<LoadedSkill[]> {

--- a/src/tools/skill-mcp.ts
+++ b/src/tools/skill-mcp.ts
@@ -167,7 +167,7 @@ export function createSkillMcpTool(options: CreateSkillMcpToolOptions): ToolDefi
           `MCP server "${args.mcp_name}" not found.\n\n` +
           `Available MCP servers in loaded skills:\n` +
           formatAvailableMcps(skills) + '\n\n' +
-          `Hint: Ensure the skill is located in a supported directory (.opencode/skills, .claude/skills, .agents/skills, ~/.config/opencode/skills, ~/.claude/skills, ~/.agents/skills), then restart OpenCode.`
+          `Hint: Verify mcp_name matches an embedded MCP definition. If you added or moved the skill in a supported skills directory, restart OpenCode to refresh discovery.`
         )
       }
 


### PR DESCRIPTION
Addresses the post-merge verification failure before publishing #9.

- Align the scope assertion with the merged distinct-scope behavior.
- Correct the discovery comment and MCP troubleshooting hint.
- Clarify that npm installation does not copy the bundled example skill.

Verified with 25 passing tests, TypeScript build, and npm package dry-run.